### PR TITLE
Update OuroClient to utilize TemplateDialog and ITemplateEndpoint

### DIFF
--- a/Ouroboros/Chaining/TemplateDialog/Commands/Send.cs
+++ b/Ouroboros/Chaining/TemplateDialog/Commands/Send.cs
@@ -4,23 +4,27 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Ouroboros.Chaining.TemplateDialog.Templates;
+using Ouroboros.Endpoints;
 
 namespace Ouroboros.Chaining.TemplateDialog.Commands;
 internal class Send<TDialogTemplate> : ITemplateCommand
 {
 	public TDialogTemplate Template { get; set; }
 	public string TemplateName { get; set; }
+	public ITemplateEndpoint? CustomEndpoint { get; set; }
 
-	public Send(TDialogTemplate template)
+	public Send(TDialogTemplate template, ITemplateEndpoint? customEndpoint = null)
 	{
 		Template = template;
 		TemplateName = nameof(template);
+		CustomEndpoint = customEndpoint;
 	}
 
-	public Send(string templateName, TDialogTemplate template)
+	public Send(string templateName, TDialogTemplate template, ITemplateEndpoint? customEndpoint = null)
 	{
 		TemplateName = templateName;
 		Template = template;
+		CustomEndpoint = customEndpoint;
 	}
 
 }

--- a/Ouroboros/Chaining/TemplateDialog/Storage.cs
+++ b/Ouroboros/Chaining/TemplateDialog/Storage.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Ouroboros.Chaining.TemplateDialog;
+public static class Storage
+{
+	public static string GetByName(string name)
+	{
+		return $"[[x]]{name}[[x]]";
+	}
+}

--- a/Ouroboros/Chaining/TemplateDialog/TemplateDialog.cs
+++ b/Ouroboros/Chaining/TemplateDialog/TemplateDialog.cs
@@ -15,7 +15,7 @@ using Z.Core.Extensions;
 namespace Ouroboros.Chaining.TemplateDialog;
 public class TemplateDialog
 {
-	private readonly ITemplateEndpoint AiEndpoint;
+	private readonly OuroClient Client;
 
 	/// <summary>
 	/// Internal list of chained commands. These are executed sequentially,
@@ -63,9 +63,9 @@ public class TemplateDialog
 		return this;
 	}
 
-	public TemplateDialog Send(string templateName, IDialogTemplate template)
+	public TemplateDialog Send(string templateName, IDialogTemplate template, ITemplateEndpoint? customEndpoint = null)
 	{
-		Commands.Add(new Send<IDialogTemplate>(templateName, template));
+		Commands.Add(new Send<IDialogTemplate>(templateName, template, customEndpoint));
 
 		return this;
 	}
@@ -151,7 +151,7 @@ public class TemplateDialog
 			}
 			
 			//Await Endpoint Response
-			var response = await AiEndpoint.SendTemplateAsync(send.TemplateName, send.Template);
+			var response = await Client.SendTemplateAsync(send.TemplateName, send.Template, send.CustomEndpoint);
 
 			//Parse response and return
 			if (!response.Success)
@@ -174,9 +174,9 @@ public class TemplateDialog
 		
 	#endregion
 
-	public TemplateDialog(ITemplateEndpoint aiEndpoint)
+	public TemplateDialog(OuroClient client)
 	{
-		AiEndpoint = aiEndpoint;
+		Client = client;
 	}
 
 }

--- a/Ouroboros/Chaining/TemplateDialog/TemplateDialog.cs
+++ b/Ouroboros/Chaining/TemplateDialog/TemplateDialog.cs
@@ -48,24 +48,20 @@ public class TemplateDialog
 	
 		private Dictionary<string, string> VariableStorage = new();
 
-		public static string GetByName(string name)
-		{
-			return $"[[x]]{name}[[x]]";
-		}
 	#endregion 
 	
 	#region Builder Pattern Commands
 	
-	public TemplateDialog Send(IDialogTemplate template)
+	public TemplateDialog Send(IOuroTemplateBase templateBase, ITemplateEndpoint? customEndpoint = null)
 	{
-		Commands.Add(new Send<IDialogTemplate>(template));
+		Commands.Add(new Send<IOuroTemplateBase>(templateBase, customEndpoint));
 
 		return this;
 	}
 
-	public TemplateDialog Send(string templateName, IDialogTemplate template, ITemplateEndpoint? customEndpoint = null)
+	public TemplateDialog Send(string templateName, IOuroTemplateBase templateBase, ITemplateEndpoint? customEndpoint = null)
 	{
-		Commands.Add(new Send<IDialogTemplate>(templateName, template, customEndpoint));
+		Commands.Add(new Send<IOuroTemplateBase>(templateName, templateBase, customEndpoint));
 
 		return this;
 	}
@@ -98,7 +94,7 @@ public class TemplateDialog
 			{
 				switch (command)
 				{
-					case Send<IDialogTemplate> send:
+					case Send<IOuroTemplateBase> send:
 						LastResponse = await HandleSend(send);
 						break;
 					case StoreOutputAs storeOutputAs:
@@ -112,7 +108,7 @@ public class TemplateDialog
 			return LastResponse ?? new OuroResponseFailure("Unknown Error");
 		}
 
-		private async Task<OuroResponseBase> HandleSend(Send<IDialogTemplate> send)
+		private async Task<OuroResponseBase> HandleSend(Send<IOuroTemplateBase> send)
 		{
 			var templateType = send.Template.GetType();
 

--- a/Ouroboros/Chaining/TemplateDialog/Templates/IOuroTemplateBase.cs
+++ b/Ouroboros/Chaining/TemplateDialog/Templates/IOuroTemplateBase.cs
@@ -5,6 +5,6 @@ using System.Text;
 using System.Threading.Tasks;
 
 namespace Ouroboros.Chaining.TemplateDialog.Templates;
-public interface IDialogTemplate
+public interface IOuroTemplateBase
 {
 }

--- a/Ouroboros/Config/UseOuroborosExtension.cs
+++ b/Ouroboros/Config/UseOuroborosExtension.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+using Ouroboros.Endpoints;
 
 namespace Ouroboros.Config;
 
@@ -8,9 +9,9 @@ public static class UseOuroborosExtension
     /// <summary>
     /// Registers the Ouroboros Client as a transient service.
     /// </summary>
-    public static IServiceCollection AddOuroboros(this IServiceCollection services, string apiKey)
+    public static IServiceCollection AddOuroboros(this IServiceCollection services, string apiKey, ITemplateEndpoint? endpoint = null)
     {
-        services.AddTransient<OuroClient>(x => new OuroClient(apiKey));
+        services.AddTransient<OuroClient>(x => new OuroClient(apiKey, endpoint));
 
         return services;
     }

--- a/Ouroboros/Endpoints/ITemplateEndpoint.cs
+++ b/Ouroboros/Endpoints/ITemplateEndpoint.cs
@@ -9,10 +9,7 @@ using Ouroboros.Responses;
 namespace Ouroboros.Endpoints;
 public interface ITemplateEndpoint
 {
-	public string Name { get; set; }
-	public Dictionary<string, string> Parameters { get; set; }
-
-	Task<OuroResponseBase> SendTemplateAsync(string templateName, IDialogTemplate template);
+	Task<OuroResponseBase> SendTemplateAsync(string templateName, IOuroTemplateBase templateBase);
 
 	
 

--- a/Ouroboros/OuroClient.cs
+++ b/Ouroboros/OuroClient.cs
@@ -51,26 +51,26 @@ public class OuroClient
 		    TemplateRequestHandler = endpoint;
 	    }
 
-	    public async Task<OuroResponseBase> SendTemplateAsync(IDialogTemplate template,
+	    public async Task<OuroResponseBase> SendTemplateAsync(IOuroTemplateBase templateBase,
 		    ITemplateEndpoint? customEndpoint = null)
 	    {
 		    if (customEndpoint != null)
-			    return await customEndpoint.SendTemplateAsync(nameof(template), template);
+			    return await customEndpoint.SendTemplateAsync(nameof(templateBase), templateBase);
 
             if (TemplateRequestHandler != null)
-                return await TemplateRequestHandler.SendTemplateAsync(nameof(template), template);
+                return await TemplateRequestHandler.SendTemplateAsync(nameof(templateBase), templateBase);
 
             throw new NotImplementedException("OuroClient does not have a TemplateEndpoint. Either set an endpoint on OuroClient using SetTemplateEndpoint, or provide an ITemplateEndpoint.");
 	    }
 
-	    public async Task<OuroResponseBase> SendTemplateAsync(string templateName, IDialogTemplate template,
+	    public async Task<OuroResponseBase> SendTemplateAsync(string templateName, IOuroTemplateBase templateBase,
 		    ITemplateEndpoint? customEndpoint = null)
 	    {
 		    if (customEndpoint != null)
-			    return await customEndpoint.SendTemplateAsync(templateName, template);
+			    return await customEndpoint.SendTemplateAsync(templateName, templateBase);
 
 		    if (TemplateRequestHandler != null)
-			    return await TemplateRequestHandler.SendTemplateAsync(templateName, template);
+			    return await TemplateRequestHandler.SendTemplateAsync(templateName, templateBase);
 
 		    throw new NotImplementedException("OuroClient does not have a TemplateEndpoint. Either set an endpoint on OuroClient using SetTemplateEndpoint, or provide an ITemplateEndpoint.");
 	    }

--- a/Ouroboros/OuroClient.cs
+++ b/Ouroboros/OuroClient.cs
@@ -1,3 +1,7 @@
+using System;
+using Ouroboros.Chaining.TemplateDialog;
+using Ouroboros.Chaining.TemplateDialog.Templates;
+using Ouroboros.Endpoints;
 using OpenAI;
 using OpenAI.Managers;
 using OpenAI.ObjectModels.RequestModels;
@@ -12,19 +16,6 @@ using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using OpenAI.Tokenizer.GPT3;
-
-using System;
-using AI.Dev.OpenAI.GPT;
-using OpenAI.Managers;
-using OpenAI;
-using OpenAI.ObjectModels.RequestModels;
-using Ouroboros.Chaining;
-using Ouroboros.Chaining.TemplateDialog;
-using Ouroboros.Chaining.TemplateDialog.Templates;
-using Ouroboros.Endpoints;
-using Ouroboros.LargeLanguageModels.ChatCompletions;
-using Ouroboros.Responses;
-
 
 [assembly: InternalsVisibleTo("Ouroboros.Test")]
 


### PR DESCRIPTION
- OuroClient now accepts ITemplateEndpoint as part of its constructor, or allows it to be set manually.
- TemplateDialog uses OuroClient's ITemplateEndpoint, but can also override that endpoint with a custom ITemplateEndpoint.
- Updated some naming around TemplateDialog (like Storage.GetByName()) to clean things up.